### PR TITLE
Fixes build error and a warning on VS2017 Community Edition

### DIFF
--- a/SCTicTacToe/SCTicTacToe/MainWindow.xaml
+++ b/SCTicTacToe/SCTicTacToe/MainWindow.xaml
@@ -30,7 +30,7 @@
                         ScaleX="{Binding ElementName=myMainWindow, Path=ScaleValue}"
                         ScaleY="{Binding ElementName=myMainWindow, Path=ScaleValue}" />
         </Grid.LayoutTransform>
-        <Image Name="Background" Opacity="0.8" Source="{Binding CurrentBackground}" Margin="10" Stretch="UniformToFill"/>
+        <Image Opacity="0.8" Source="{Binding CurrentBackground}" Margin="10" Stretch="UniformToFill"/>
         <DockPanel HorizontalAlignment="Center" VerticalAlignment="Top">
             <Border Grid.Row="0" Padding="0" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,0,0,0" Width="740" DockPanel.Dock="Top">
                 <Image>

--- a/SCTicTacToe/SCTicTacToe/SCTicTacToe.csproj
+++ b/SCTicTacToe/SCTicTacToe/SCTicTacToe.csproj
@@ -69,6 +69,9 @@
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Expression.Interactions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\Microsoft.Expression.Interactions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -90,7 +93,9 @@
       <HintPath>..\packages\System.Reactive.Windows.Threading.3.1.1\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
     </Reference>
     <Reference Include="System.Windows" />
-    <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Windows.Interactivity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Windows.Interactivity.WPF.2.0.20525\lib\net40\System.Windows.Interactivity.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -166,7 +171,9 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <Resource Include="Starcraft Normal.ttf" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SCTicTacToe/SCTicTacToe/packages.config
+++ b/SCTicTacToe/SCTicTacToe/packages.config
@@ -7,5 +7,6 @@
   <package id="System.Reactive.Linq" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.PlatformServices" version="3.1.1" targetFramework="net452" />
   <package id="System.Reactive.Windows.Threading" version="3.1.1" targetFramework="net452" />
+  <package id="System.Windows.Interactivity.WPF" version="2.0.20525" targetFramework="net452" />
   <package id="XamlAnimatedGif" version="1.1.9" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Fixes build error, missing System.Windows.Interactivity on VS2017 Community Edition
- Fixes build warning about instance name overriding base in XAML
